### PR TITLE
Add user configurable blocksize option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -558,6 +558,15 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
+dnl Check for MSG_DONTWAIT
+AC_MSG_CHECKING(for MSG_DONTWAIT)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
+ [[ int f = MSG_DONTWAIT; ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_DONTWAIT, 1,[Define this symbol if you have MSG_DONTWAIT]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+
 AC_MSG_CHECKING([for visibility attribute])
 AC_LINK_IFELSE([AC_LANG_SOURCE([
   int foo_def( void ) __attribute__((visibility("default")));

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,7 @@ Bitcoin Core 0.14.99
 
 Setup
 ---------------------
-Bitcoin Core is the original Bitcoin client and it builds the backbone of the network. However, it downloads and stores the entire history of Bitcoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
+Bitcoin Core is the original Bitcoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of Bitcoin transactions (which is currently more than 100 GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
 To download Bitcoin Core, visit [bitcoincore.org](https://bitcoincore.org/en/releases/).
 

--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -336,7 +336,7 @@ There will be a lot of warnings printed during the build of the image. These can
 Getting and building the inputs
 --------------------------------
 
-At this point you have two options, you can either use the automated script (found in [contrib/gitian-build.sh](/contrib/gitian-build.sh)) or you could manually do everything by following this guide. If you're using the automated script, then run it with the "--setup" command. Afterwards, run it with the "--build" command (example: "contrib/gitian-building.sh -b signer 0.13.0"). Otherwise ignore this.
+At this point you have two options, you can either use the automated script (found in [contrib/gitian-build.sh](/contrib/gitian-build.sh)) or you could manually do everything by following this guide. If you're using the automated script, then run it with the "--setup" command. Afterwards, run it with the "--build" command (example: "contrib/gitian-build.sh -b signer 0.13.0"). Otherwise ignore this.
 
 Follow the instructions in [doc/release-process.md](release-process.md#fetch-and-create-inputs-first-time-or-when-dependency-versions-change)
 in the bitcoin repository under 'Fetch and create inputs' to install sources which require

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -69,12 +69,8 @@ class BIP65Test(BitcoinTestFramework):
         if (self.nodes[0].getblockcount() != cnt + 1051):
             raise AssertionError("Failed to mine a version=4 block")
 
-        # Mine 1 old-version blocks
-        try:
-            self.nodes[1].generate(1)
-            raise AssertionError("Succeeded to mine a version=3 block after 950 version=4 blocks")
-        except JSONRPCException:
-            pass
+        # Mine 1 old-version blocks. This should fail
+        assert_raises_jsonrpc(-1,"CreateNewBlock: TestBlockValidity failed: bad-version(0x00000003)", self.nodes[1].generate, 1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1051):
             raise AssertionError("Accepted a version=3 block after 950 version=4 blocks")

--- a/qa/rpc-tests/bipdersig.py
+++ b/qa/rpc-tests/bipdersig.py
@@ -68,12 +68,8 @@ class BIP66Test(BitcoinTestFramework):
         if (self.nodes[0].getblockcount() != cnt + 1051):
             raise AssertionError("Failed to mine a version=3 block")
 
-        # Mine 1 old-version blocks
-        try:
-            self.nodes[1].generate(1)
-            raise AssertionError("Succeeded to mine a version=2 block after 950 version=3 blocks")
-        except JSONRPCException:
-            pass
+        # Mine 1 old-version blocks. This should fail
+        assert_raises_jsonrpc(-1, "CreateNewBlock: TestBlockValidity failed: bad-version(0x00000002)", self.nodes[1].generate, 1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1051):
             raise AssertionError("Accepted a version=2 block after 950 version=3 blocks")

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -14,10 +14,9 @@ Tests correspond to code in rpc/blockchain.cpp.
 from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.authproxy import JSONRPCException
 from test_framework.util import (
     assert_equal,
-    assert_raises,
+    assert_raises_jsonrpc,
     assert_is_hex_string,
     assert_is_hash_string,
     start_nodes,
@@ -58,8 +57,7 @@ class BlockchainTest(BitcoinTestFramework):
     def _test_getblockheader(self):
         node = self.nodes[0]
 
-        assert_raises(
-            JSONRPCException, lambda: node.getblockheader('nonsense'))
+        assert_raises_jsonrpc(-5, "Block not found", node.getblockheader, "nonsense")
 
         besthash = node.getbestblockhash()
         secondbesthash = node.getblockhash(199)

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -30,19 +30,10 @@ class DisableWalletTest (BitcoinTestFramework):
         x = self.nodes[0].validateaddress('mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
         assert(x['isvalid'] == True)
 
-        # Checking mining to an address without a wallet
-        try:
-            self.nodes[0].generatetoaddress(1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
-        except JSONRPCException as e:
-            assert("Invalid address" not in e.error['message'])
-            assert("ProcessNewBlock, block not accepted" not in e.error['message'])
-            assert("Couldn't create new block" not in e.error['message'])
-
-        try:
-            self.nodes[0].generatetoaddress(1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
-            raise AssertionError("Must not mine to invalid address!")
-        except JSONRPCException as e:
-            assert("Invalid address" in e.error['message'])
+        # Checking mining to an address without a wallet. Generating to a valid address should succeed
+        # but generating to an invalid address will fail.
+        self.nodes[0].generatetoaddress(1, 'mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ')
+        assert_raises_jsonrpc(-5, "Invalid address", self.nodes[0].generatetoaddress, 1, '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
 
 if __name__ == '__main__':
     DisableWalletTest ().main ()

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -105,7 +105,7 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
 
         # Test 3: Truncated final tx
         lastbyte = txlist[-1].pop()
-        assert_raises(JSONRPCException, assert_template, node, tmpl, txlist, 'n/a')
+        assert_raises_jsonrpc(-22, "Block decode failed", assert_template, node, tmpl, txlist, 'n/a')
         txlist[-1].append(lastbyte)
 
         # Test 4: Add an invalid tx to the end (duplicate of gen tx)
@@ -126,7 +126,7 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
 
         # Test 7: Bad tx count
         txlist.append(b'')
-        assert_raises(JSONRPCException, assert_template, node, tmpl, txlist, 'n/a')
+        assert_raises_jsonrpc(-22, 'Block decode failed', assert_template, node, tmpl, txlist, 'n/a')
         txlist.pop()
 
         # Test 8: Bad bits

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -28,11 +28,7 @@ class KeyPoolTest(BitcoinTestFramework):
         assert(addr_before_encrypting_data['hdmasterkeyid'] != wallet_info['hdmasterkeyid'])
         assert(addr_data['hdmasterkeyid'] == wallet_info['hdmasterkeyid'])
         
-        try:
-            addr = nodes[0].getnewaddress()
-            raise AssertionError('Keypool should be exhausted after one address')
-        except JSONRPCException as e:
-            assert(e.error['code']==-12)
+        assert_raises_jsonrpc(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)
 
         # put three new keys in the keypool
         nodes[0].walletpassphrase('test', 12000)
@@ -48,11 +44,7 @@ class KeyPoolTest(BitcoinTestFramework):
         # assert that four unique addresses were returned
         assert(len(addr) == 4)
         # the next one should fail
-        try:
-            addr = nodes[0].getrawchangeaddress()
-            raise AssertionError('Keypool should be exhausted after three addresses')
-        except JSONRPCException as e:
-            assert(e.error['code']==-12)
+        assert_raises_jsonrpc(-12, "Keypool ran out", nodes[0].getrawchangeaddress)
 
         # refill keypool with three new addresses
         nodes[0].walletpassphrase('test', 1)
@@ -66,11 +58,7 @@ class KeyPoolTest(BitcoinTestFramework):
         nodes[0].generate(1)
         nodes[0].generate(1)
         nodes[0].generate(1)
-        try:
-            nodes[0].generate(1)
-            raise AssertionError('Keypool should be exhausted after three addesses')
-        except JSONRPCException as e:
-            assert(e.error['code']==-12)
+        assert_raises_jsonrpc(-12, "Keypool ran out", nodes[0].generate, 1)
 
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -112,10 +112,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN + 1000)
 
         # Adding one more transaction on to the chain should fail.
-        try:
-            self.chain_transaction(self.nodes[0], txid, vout, value, fee, 1)
-        except JSONRPCException as e:
-            self.log.info("too-long-ancestor-chain successfully rejected")
+        assert_raises_jsonrpc(-26, "too-long-mempool-chain", self.chain_transaction, self.nodes[0], txid, vout, value, fee, 1)
 
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
@@ -155,19 +152,19 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for i in range(10):
             transaction_package.append({'txid': txid, 'vout': i, 'amount': sent_value})
 
-        for i in range(MAX_DESCENDANTS):
+        # Sign and send up to MAX_DESCENDANT transactions chained off the parent tx
+        for i in range(MAX_DESCENDANTS - 1):
             utxo = transaction_package.pop(0)
-            try:
-                (txid, sent_value) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
-                for j in range(10):
-                    transaction_package.append({'txid': txid, 'vout': j, 'amount': sent_value})
-                if i == MAX_DESCENDANTS - 2:
-                    mempool = self.nodes[0].getrawmempool(True)
-                    assert_equal(mempool[parent_transaction]['descendantcount'], MAX_DESCENDANTS)
-            except JSONRPCException as e:
-                self.log.info(e.error['message'])
-                assert_equal(i, MAX_DESCENDANTS - 1)
-                self.log.info("tx that would create too large descendant package successfully rejected")
+            (txid, sent_value) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
+            for j in range(10):
+                transaction_package.append({'txid': txid, 'vout': j, 'amount': sent_value})
+
+        mempool = self.nodes[0].getrawmempool(True)
+        assert_equal(mempool[parent_transaction]['descendantcount'], MAX_DESCENDANTS)
+
+        # Sending one more chained transaction will fail
+        utxo = transaction_package.pop(0)
+        assert_raises_jsonrpc(-26, "too-long-mempool-chain", self.chain_transaction, self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
 
         # TODO: check that node1's mempool is as expected
 

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -30,9 +30,10 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        start_count = self.nodes[0].getblockcount()
+        # Start with a 200 block chain
+        assert_equal(self.nodes[0].getblockcount(), 200)
 
-        # Mine three blocks. After this, nodes[0] blocks
+        # Mine four blocks. After this, nodes[0] blocks
         # 101, 102, and 103 are spend-able.
         new_blocks = self.nodes[1].generate(4)
         self.sync_all()
@@ -52,19 +53,21 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         spend_102_raw = create_tx(self.nodes[0], coinbase_txids[2], node0_address, 49.99)
         spend_103_raw = create_tx(self.nodes[0], coinbase_txids[3], node0_address, 49.99)
 
-        # Create a block-height-locked transaction which will be invalid after reorg
+        # Create a transaction which is time-locked to two blocks in the future
         timelock_tx = self.nodes[0].createrawtransaction([{"txid": coinbase_txids[0], "vout": 0}], {node0_address: 49.99})
         # Set the time lock
         timelock_tx = timelock_tx.replace("ffffffff", "11111191", 1)
         timelock_tx = timelock_tx[:-8] + hex(self.nodes[0].getblockcount() + 2)[2:] + "000000"
         timelock_tx = self.nodes[0].signrawtransaction(timelock_tx)["hex"]
-        assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, timelock_tx)
+        # This will raise an exception because the timelock transaction is too immature to spend
+        assert_raises_jsonrpc(-26, "non-final", self.nodes[0].sendrawtransaction, timelock_tx)
 
         # Broadcast and mine spend_102 and 103:
         spend_102_id = self.nodes[0].sendrawtransaction(spend_102_raw)
         spend_103_id = self.nodes[0].sendrawtransaction(spend_103_raw)
         self.nodes[0].generate(1)
-        assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, timelock_tx)
+        # Time-locked transaction is still too immature to spend
+        assert_raises_jsonrpc(-26,'non-final', self.nodes[0].sendrawtransaction, timelock_tx)
 
         # Create 102_1 and 103_1:
         spend_102_1_raw = create_tx(self.nodes[0], spend_102_id, node1_address, 49.98)
@@ -73,6 +76,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # Broadcast and mine 103_1:
         spend_103_1_id = self.nodes[0].sendrawtransaction(spend_103_1_raw)
         last_block = self.nodes[0].generate(1)
+        # Time-locked transaction can now be spent
         timelock_tx_id = self.nodes[0].sendrawtransaction(timelock_tx)
 
         # ... now put spend_101 and spend_102_1 in memory pools:
@@ -85,6 +89,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         for node in self.nodes:
             node.invalidateblock(last_block[0])
+        # Time-locked transaction is now too immature and has been removed from the mempool
+        # spend_103_1 has been re-orged out of the chain and is back in the mempool
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, spend_103_1_id})
 
         # Use invalidateblock to re-org back and make all those coinbase spends

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -45,7 +45,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         spend_101_id = self.nodes[0].sendrawtransaction(spends_raw[0])
 
         # coinbase at height 102 should be too immature to spend
-        assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, spends_raw[1])
+        assert_raises_jsonrpc(-26,"bad-txns-premature-spend-of-coinbase", self.nodes[0].sendrawtransaction, spends_raw[1])
 
         # mempool should have just spend_101:
         assert_equal(self.nodes[0].getrawmempool(), [ spend_101_id ])

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -25,6 +25,8 @@ class PreviousSpendableOutput(object):
         self.tx = tx
         self.n = n  # the output we're spending
 
+MAX_BLOCK_BASE_SIZE = 1000000
+
 #  Use this class for tests that require behavior other than normal "mininode" behavior.
 #  For now, it is used to serialize a bloated varint (b64).
 class CBrokenBlock(CBlock):
@@ -61,6 +63,11 @@ class FullBlockTest(ComparisonTestFramework):
         self.coinbase_pubkey = self.coinbase_key.get_pubkey()
         self.tip = None
         self.blocks = {}
+
+    def setup_nodes(self):
+        return start_nodes(4, self.options.tmpdir,
+                extra_args = [["-maxblocksize=1000000", "--blocksizeacceptlimit=1"]])
+
 
     def add_options(self, parser):
         super().add_options(parser)
@@ -377,7 +384,7 @@ class FullBlockTest(ComparisonTestFramework):
         tx.vout = [CTxOut(0, script_output)]
         b24 = update_block(24, [tx])
         assert_equal(len(b24.serialize()), MAX_BLOCK_BASE_SIZE+1)
-        yield rejected(RejectResult(16, b'bad-blk-length'))
+        yield rejected()
 
         block(25, spend=out[7])
         yield rejected()

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -107,13 +107,9 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         tx_hex = self.nodes[0].signrawtransaction(raw_tx)["hex"]
         tx_id = self.nodes[0].decoderawtransaction(tx_hex)["txid"]
 
-        try:
-            self.nodes[0].sendrawtransaction(tx_hex)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26) # insufficient fee
-            assert(tx_id not in self.nodes[0].getrawmempool())
-        else:
-            assert(False)
+        # This will raise an exception due to min relay fee not being met
+        assert_raises_jsonrpc(-26, "66: min relay fee not met", self.nodes[0].sendrawtransaction, tx_hex)
+        assert(tx_id not in self.nodes[0].getrawmempool())
 
         # This is a less than 1000-byte transaction, so just set the fee
         # to be the minimum for a 1000 byte transaction and check that it is

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -6,7 +6,9 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.mininode import COIN, MAX_BLOCK_BASE_SIZE
+from test_framework.mininode import COIN
+
+MAX_BLOCK_BASE_SIZE = 1000000
 
 class PrioritiseTransactionTest(BitcoinTestFramework):
 
@@ -21,7 +23,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.nodes = []
         self.is_network_split = False
 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-printpriority=1"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-printpriority=1", "--blocksizeacceptlimit=1"]))
         self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 
     def run_test(self):

--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -125,12 +125,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b.vout = [CTxOut(1*COIN, CScript([b'b']))]
         tx1b_hex = txToHex(tx1b)
 
-        try:
-            tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26) # insufficient fee
-        else:
-            assert(False)
+        # This will raise an exception due to insufficient fee
+        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
 
         # Extra 0.1 BTC fee
         tx1b = CTransaction()
@@ -172,12 +168,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         dbl_tx.vout = [CTxOut(initial_nValue - 30*COIN, CScript([1]))]
         dbl_tx_hex = txToHex(dbl_tx)
 
-        try:
-            self.nodes[0].sendrawtransaction(dbl_tx_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26) # insufficient fee
-        else:
-            assert(False) # transaction mistakenly accepted!
+        # This will raise an exception due to insufficient fee
+        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
         # Accepted with sufficient fee
         dbl_tx = CTransaction()
@@ -237,12 +229,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         dbl_tx.vout = [CTxOut(initial_nValue - fee*n, CScript([1]))]
         dbl_tx_hex = txToHex(dbl_tx)
-        try:
-            self.nodes[0].sendrawtransaction(dbl_tx_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26) # insufficient fee
-        else:
-            assert(False)
+        # This will raise an exception due to insufficient fee
+        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
         # 1 BTC fee is enough
         dbl_tx = CTransaction()
@@ -269,13 +257,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
             dbl_tx.vout = [CTxOut(initial_nValue - 2*fee*n, CScript([1]))]
             dbl_tx_hex = txToHex(dbl_tx)
-            try:
-                self.nodes[0].sendrawtransaction(dbl_tx_hex, True)
-            except JSONRPCException as exp:
-                assert_equal(exp.error['code'], -26)
-                assert_equal("too many potential replacements" in exp.error['message'], True)
-            else:
-                assert(False)
+            # This will raise an exception
+            assert_raises_jsonrpc(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
             for tx in tree_txs:
                 tx.rehash()
@@ -298,12 +281,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b.vout = [CTxOut(int(0.001*COIN), CScript([b'a'*999000]))]
         tx1b_hex = txToHex(tx1b)
 
-        try:
-            tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26) # insufficient fee
-        else:
-            assert(False)
+        # This will raise an exception due to insufficient fee
+        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
 
     def test_spends_of_conflicting_outputs(self):
         """Replacements that spend conflicting tx outputs are rejected"""
@@ -325,12 +304,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2.vout = tx1a.vout
         tx2_hex = txToHex(tx2)
 
-        try:
-            tx2_txid = self.nodes[0].sendrawtransaction(tx2_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-        else:
-            assert(False)
+        # This will raise an exception
+        assert_raises_jsonrpc(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, True)
 
         # Spend tx1a's output to test the indirect case.
         tx1b = CTransaction()
@@ -346,12 +321,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2.vout = tx1a.vout
         tx2_hex = txToHex(tx2)
 
-        try:
-            tx2_txid = self.nodes[0].sendrawtransaction(tx2_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-        else:
-            assert(False)
+        # This will raise an exception
+        assert_raises_jsonrpc(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, True)
 
     def test_new_unconfirmed_inputs(self):
         """Replacements that add new unconfirmed inputs are rejected"""
@@ -369,12 +340,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2.vout = tx1.vout
         tx2_hex = txToHex(tx2)
 
-        try:
-            tx2_txid = self.nodes[0].sendrawtransaction(tx2_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-        else:
-            assert(False)
+        # This will raise an exception
+        assert_raises_jsonrpc(-26, "replacement-adds-unconfirmed", self.nodes[0].sendrawtransaction, tx2_hex, True)
 
     def test_too_many_replacements(self):
         """Replacements that evict too many transactions are rejected"""
@@ -419,13 +386,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         double_tx.vout = [CTxOut(double_spend_value, CScript([b'a']))]
         double_tx_hex = txToHex(double_tx)
 
-        try:
-            self.nodes[0].sendrawtransaction(double_tx_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-            assert_equal("too many potential replacements" in exp.error['message'], True)
-        else:
-            assert(False)
+        # This will raise an exception
+        assert_raises_jsonrpc(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, double_tx_hex, True)
 
         # If we remove an input, it should pass
         double_tx = CTransaction()
@@ -451,13 +413,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b.vout = [CTxOut(int(0.9*COIN), CScript([b'b']))]
         tx1b_hex = txToHex(tx1b)
 
-        try:
-            tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-        else:
-            self.log.info(tx1b_txid)
-            assert(False)
+        # This will raise an exception
+        assert_raises_jsonrpc(-26, "txn-mempool-conflict", self.nodes[0].sendrawtransaction, tx1b_hex, True)
 
         tx1_outpoint = make_utxo(self.nodes[0], int(1.1*COIN))
 
@@ -474,12 +431,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2b.vout = [CTxOut(int(0.9*COIN), CScript([b'b']))]
         tx2b_hex = txToHex(tx2b)
 
-        try:
-            tx2b_txid = self.nodes[0].sendrawtransaction(tx2b_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-        else:
-            assert(False)
+        # This will raise an exception
+        assert_raises_jsonrpc(-26, "txn-mempool-conflict", self.nodes[0].sendrawtransaction, tx2b_hex, True)
 
         # Now create a new transaction that spends from tx1a and tx2a
         # opt-in on one of the inputs
@@ -531,12 +484,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b_hex = txToHex(tx1b)
 
         # Verify tx1b cannot replace tx1a.
-        try:
-            tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-        else:
-            assert(False)
+        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
 
         # Use prioritisetransaction to set tx1a's fee to 0.
         self.nodes[0].prioritisetransaction(tx1a_txid, int(-0.1*COIN))
@@ -563,12 +511,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2b_hex = txToHex(tx2b)
 
         # Verify tx2b cannot replace tx2a.
-        try:
-            tx2b_txid = self.nodes[0].sendrawtransaction(tx2b_hex, True)
-        except JSONRPCException as exp:
-            assert_equal(exp.error['code'], -26)
-        else:
-            assert(False)
+        assert_raises_jsonrpc(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx2b_hex, True)
 
         # Now prioritise tx2b to have a higher modified fee
         self.nodes[0].prioritisetransaction(tx2b.hash, int(0.1*COIN))

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -92,11 +92,7 @@ class RPCBindTest(BitcoinTestFramework):
 
         # Check that with invalid rpcallowip, we are denied
         self.run_allowip_test([non_loopback_ip], non_loopback_ip, defaultport)
-        try:
-            self.run_allowip_test(['1.1.1.1'], non_loopback_ip, defaultport)
-            assert(not 'Connection not denied by rpcallowip as expected')
-        except JSONRPCException:
-            pass
+        assert_raises_jsonrpc(-342, "non-JSON HTTP response with '403 Forbidden' from server", self.run_allowip_test, ['1.1.1.1'], non_loopback_ip, defaultport)
 
 if __name__ == '__main__':
     RPCBindTest().main()

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -42,7 +42,6 @@ MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
 MAX_INV_SZ = 50000
-MAX_BLOCK_BASE_SIZE = 1000000
 
 COIN = 100000000 # 1 btc in satoshis
 

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -71,7 +71,7 @@ class WalletTest (BitcoinTestFramework):
         unspent_0 = self.nodes[2].listunspent()[0]
         unspent_0 = {"txid": unspent_0["txid"], "vout": unspent_0["vout"]}
         self.nodes[2].lockunspent(False, [unspent_0])
-        assert_raises_message(JSONRPCException, "Insufficient funds", self.nodes[2].sendtoaddress, self.nodes[2].getnewaddress(), 20)
+        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[2].sendtoaddress, self.nodes[2].getnewaddress(), 20)
         assert_equal([unspent_0], self.nodes[2].listlockunspent())
         self.nodes[2].lockunspent(True, [unspent_0])
         assert_equal(len(self.nodes[2].listlockunspent()), 0)
@@ -251,19 +251,11 @@ class WalletTest (BitcoinTestFramework):
         txObj = self.nodes[0].gettransaction(txId)
         assert_equal(txObj['amount'], Decimal('-0.0001'))
 
-        try:
-            txId  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "1f-4")
-        except JSONRPCException as e:
-            assert("Invalid amount" in e.error['message'])
-        else:
-            raise AssertionError("Must not parse invalid amounts")
+        # This will raise an exception because the amount type is wrong
+        assert_raises_jsonrpc(-3, "Invalid amount", self.nodes[0].sendtoaddress, self.nodes[2].getnewaddress(), "1f-4")
 
-
-        try:
-            self.nodes[0].generate("2")
-            raise AssertionError("Must not accept strings as numeric")
-        except JSONRPCException as e:
-            assert("not an integer" in e.error['message'])
+        # This will raise an exception since generate does not accept a string
+        assert_raises_jsonrpc(-1, "not an integer", self.nodes[0].generate, "2")
 
         # Import address and private key to check correct behavior of spendable unspents
         # 1. Send some coins to generate new UTXO
@@ -394,7 +386,7 @@ class WalletTest (BitcoinTestFramework):
 
         node0_balance = self.nodes[0].getbalance()
         # With walletrejectlongchains we will not create the tx and store it in our wallet.
-        assert_raises_message(JSONRPCException, "mempool chain", self.nodes[0].sendtoaddress, sending_addr, node0_balance - Decimal('0.01'))
+        assert_raises_jsonrpc(-4, "Transaction has too long of a mempool chain", self.nodes[0].sendtoaddress, sending_addr, node0_balance - Decimal('0.01'))
 
         # Verify nothing new in wallet
         assert_equal(total_txs, len(self.nodes[0].listtransactions("*",99999)))

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -88,12 +88,12 @@ std::string FormatFullVersion()
 /** 
  * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) 
  */
-std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit)
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nMaxBlockSize)
 {
-    if (nSizeLimit) {
+    if (nMaxBlockSize) {
         // Announce our excessive block acceptence.
         std::stringstream ss;
-        double dMaxBlockSize = static_cast<double>(nSizeLimit) / 1000000;
+        double dMaxBlockSize = static_cast<double>(nMaxBlockSize) / 1000000;
         ss << "EB" << std::setprecision(static_cast<int>(std::log10(dMaxBlockSize))+7) << dMaxBlockSize;
         comments.insert(comments.end(), ss.str());
     }

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -5,8 +5,11 @@
 #include "clientversion.h"
 
 #include "tinyformat.h"
+#include "policy/policy.h"
 
 #include <string>
+#include <iomanip>
+#include <cmath>
 
 /**
  * Name of client reported in the 'version' message. Report the same name
@@ -85,8 +88,16 @@ std::string FormatFullVersion()
 /** 
  * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) 
  */
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit)
 {
+    if (nSizeLimit) {
+        // Announce our excessive block acceptence.
+        std::stringstream ss;
+        double dMaxBlockSize = static_cast<double>(nSizeLimit) / 1000000;
+        ss << "EB" << std::setprecision(static_cast<int>(std::log10(dMaxBlockSize))+7) << dMaxBlockSize;
+        comments.insert(comments.end(), ss.str());
+    }
+
     std::ostringstream ss;
     ss << "/";
     ss << name << ":" << FormatVersion(nClientVersion);

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -62,7 +62,7 @@ extern const std::string CLIENT_BUILD;
 
 
 std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit);
 
 #endif // WINDRES_PREPROC
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -63,7 +63,7 @@ extern const std::string CLIENT_BUILD;
 
 
 std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit);
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nMaxBlockSize);
 
 #endif // WINDRES_PREPROC
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -50,6 +50,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 static const int CLIENT_VERSION =
                            1000000 * CLIENT_VERSION_MAJOR

--- a/src/compat.h
+++ b/src/compat.h
@@ -72,16 +72,6 @@ typedef u_int SOCKET;
 #define MAX_PATH            1024
 #endif
 
-// As Solaris does not have the MSG_NOSIGNAL flag for send(2) syscall, it is defined as 0
-#if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
-#define MSG_NOSIGNAL 0
-#endif
-
-// MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
-#if !defined(HAVE_MSG_DONTWAIT) && !defined(MSG_DONTWAIT)
-#define MSG_DONTWAIT 0
-#endif
-
 #if HAVE_DECL_STRNLEN == 0
 size_t strnlen( const char *start, size_t max_len);
 #endif // HAVE_DECL_STRNLEN

--- a/src/compat.h
+++ b/src/compat.h
@@ -47,9 +47,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef WIN32
-#define MSG_DONTWAIT        0
-#else
+#ifndef WIN32
 typedef u_int SOCKET;
 #include "errno.h"
 #define WSAGetLastError()   errno
@@ -77,6 +75,11 @@ typedef u_int SOCKET;
 // As Solaris does not have the MSG_NOSIGNAL flag for send(2) syscall, it is defined as 0
 #if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
+#endif
+
+// MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
+#if !defined(HAVE_MSG_DONTWAIT) && !defined(MSG_DONTWAIT)
+#define MSG_DONTWAIT 0
 #endif
 
 #if HAVE_DECL_STRNLEN == 0

--- a/src/compat.h
+++ b/src/compat.h
@@ -48,7 +48,7 @@
 #endif
 
 #ifndef WIN32
-typedef u_int SOCKET;
+typedef unsigned int SOCKET;
 #include "errno.h"
 #define WSAGetLastError()   errno
 #define WSAEINVAL           EINVAL

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1225,17 +1225,16 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     RegisterNodeSignals(GetNodeSignals());
 
     // sanitize comments per BIP-0014, format user agent and check total size
-    std::vector<std::string> uacomments;
     if (mapMultiArgs.count("-uacomment")) {
         BOOST_FOREACH(std::string cmt, mapMultiArgs.at("-uacomment"))
         {
             if (cmt != SanitizeString(cmt, SAFE_CHARS_UA_COMMENT))
                 return InitError(strprintf(_("User Agent comment (%s) contains unsafe characters."), cmt));
-            uacomments.push_back(cmt);
+            vUAComments.push_back(cmt);
         }
     }
     std::int32_t BlockSizeLimit = Policy::blockSizeAcceptLimit(); 
-    size_t userAgentLen = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments, BlockSizeLimit).size();
+    size_t userAgentLen = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, BlockSizeLimit).size();
     if (userAgentLen > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
             userAgentLen, MAX_SUBVERSION_LENGTH));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -469,7 +469,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
-    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE));
+    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE / 1e6));
+    strUsage += HelpMessageOpt("-blocksizeacceptlimitbytes,excessiveblocksize=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in bytes. Superseded by -blocksizeacceptlimit (default: %u)", DEFAULT_BLOCK_ACCEPT_SIZE));
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -469,6 +469,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE));
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
@@ -1233,10 +1234,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             uacomments.push_back(cmt);
         }
     }
-    strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments);
-    if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
+    std::int32_t BlockSizeLimit = Policy::blockSizeAcceptLimit(); 
+    size_t userAgentLen = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments, BlockSizeLimit).size();
+    if (userAgentLen > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
-            strSubVersion.size(), MAX_SUBVERSION_LENGTH));
+            userAgentLen, MAX_SUBVERSION_LENGTH));
     }
 
     if (mapMultiArgs.count("-onlynet")) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -31,6 +31,9 @@
 #include <queue>
 #include <utility>
 
+//FIXME
+std::vector<unsigned char> m_coinbaseComment;
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // BitcoinMiner
@@ -190,7 +193,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
     coinbaseTx.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
-    coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
+    coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0 << m_coinbaseComment;
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
     pblocktemplate->vchCoinbaseCommitment = GenerateCoinbaseCommitment(*pblock, pindexPrev, chainparams.GetConsensus());
     pblocktemplate->vTxFees[0] = -nFees;
@@ -466,9 +469,21 @@ void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned
     ++nExtraNonce;
     unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
-    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) + COINBASE_FLAGS;
+    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) << m_coinbaseComment;
     assert(txCoinbase.vin[0].scriptSig.size() <= 100);
 
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+
+    // read args to create m_coinbaseComment
+    std::int32_t sizeLimit = Policy::blockSizeAcceptLimit();
+
+    std::stringstream ss;
+    ss << std::fixed;
+    if ((sizeLimit % 1000000) != 0)
+      ss << std::setprecision(1) << sizeLimit / 1E6;
+    else
+      ss << (int) (sizeLimit / 1E6);
+    std::string comment = "EB" + ss.str();
+    m_coinbaseComment =  std::vector<unsigned char>(comment.begin(), comment.end());
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -206,5 +206,4 @@ private:
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
-
 #endif // BITCOIN_MINER_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -44,8 +44,13 @@
 // We add a random period time (0 to 1 seconds) to feeler connections to prevent synchronization.
 #define FEELER_SLEEP_WINDOW 1
 
-#if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
+#if !defined(HAVE_MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
+#endif
+
+// MSG_DONTWAIT is not available on some platforms, if it doesn't exist define it as 0
+#if !defined(HAVE_MSG_DONTWAIT)
+#define MSG_DONTWAIT 0
 #endif
 
 // Fix for ancient MinGW versions, that don't have defined these in ws2tcpip.h.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -77,7 +77,7 @@ bool fRelayTxes = true;
 CCriticalSection cs_mapLocalHost;
 std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};
-std::string strSubVersion;
+std::vector<std::string> vUAComments;
 
 limitedmap<uint256, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
 

--- a/src/net.h
+++ b/src/net.h
@@ -471,8 +471,8 @@ extern bool fRelayTxes;
 
 extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
 
-/** Subversion as sent to the P2P network in `version` messages */
-extern std::string strSubVersion;
+/** Comments in subversion as sent to the P2P network in `version` messages */
+extern std::vector<std::string> vUAComments;
 
 struct LocalServiceInfo {
     int nScore;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -9,6 +9,7 @@
 #include "arith_uint256.h"
 #include "blockencodings.h"
 #include "chainparams.h"
+#include "clientversion.h"
 #include "consensus/validation.h"
 #include "hash.h"
 #include "init.h"
@@ -247,12 +248,13 @@ void PushNodeVersion(CNode *pnode, CConnman& connman, int64_t nTime)
     ServiceFlags nLocalNodeServices = pnode->GetLocalServices();
     uint64_t nonce = pnode->GetLocalNonce();
     int nNodeStartingHeight = pnode->GetMyStartingHeight();
+    std::int32_t nMaxBlockSize = Policy::blockSizeAcceptLimit();
     NodeId nodeid = pnode->GetId();
     CAddress addr = pnode->addr;
 
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService(), addr.nServices));
     CAddress addrMe = CAddress(CService(), nLocalNodeServices);
-
+    std::string strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, nMaxBlockSize);
     connman.PushMessage(pnode, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERSION, PROTOCOL_VERSION, (uint64_t)nLocalNodeServices, nTime, addrYou, addrMe,
             nonce, strSubVersion, nNodeStartingHeight, ::fRelayTxes));
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -25,7 +25,7 @@
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 
-#if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
+#if !defined(HAVE_MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
 #endif
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -158,11 +158,13 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
 int32_t Policy::blockSizeAcceptLimit()
 {
-    auto limit = -1;
+    int limit = -1;
     auto userlimit = mapArgs.find("-blocksizeacceptlimit");
-    if (userlimit == mapArgs.end()) // fallback to the BitcoinUnlimited name.
-       userlimit = mapArgs.find("-excessiveblocksize");
-    if (userlimit != mapArgs.end()) {
+    if (userlimit == mapArgs.end()) { // fallback to the BitcoinUnlimited name.
+       limit = GetArg("-excessiveblocksize", -1);
+    }
+    else {
+        // this is in fractions of a megabyte (for instance "3.2")
         double limitInMB = atof(userlimit->second.c_str());
         if (limitInMB <= 0) {
             LogPrintf("Failed to understand blocksizeacceptlimit: '%s'\n", userlimit->second.c_str());

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -176,6 +176,8 @@ int32_t Policy::blockSizeAcceptLimit()
     }
     if (limit <= 0)
         limit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
+    if (limit < 1000000)
+        LogPrintf("BlockSize set to extremely low value (%d bytes), this may cause failures.\n", limit);
     return limit;
 }
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/foreach.hpp>
 
+extern std::map<std::string, std::string> mapArgs;
+
     /**
      * Check transaction inputs to mitigate two
      * potential denial-of-service attacks:
@@ -152,6 +154,25 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     }
 
     return true;
+}
+
+int32_t Policy::blockSizeAcceptLimit()
+{
+    auto limit = -1;
+    auto userlimit = mapArgs.find("-blocksizeacceptlimit");
+    if (userlimit == mapArgs.end()) // fallback to the BitcoinUnlimited name.
+       userlimit = mapArgs.find("-excessiveblocksize");
+    if (userlimit != mapArgs.end()) {
+        double limitInMB = atof(userlimit->second.c_str());
+        if (limitInMB <= 0) {
+            LogPrintf("Failed to understand blocksizeacceptlimit: '%s'\n", userlimit->second.c_str());
+        } else {
+            limit = static_cast<int32_t>(limitInMB * 10) * 1E5;
+        }
+    }
+    if (limit <= 0)
+        limit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
+    return limit;
 }
 
 bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -12,6 +12,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
+#include <cmath>
 #include <boost/foreach.hpp>
 
 extern std::map<std::string, std::string> mapArgs;
@@ -169,7 +170,8 @@ int32_t Policy::blockSizeAcceptLimit()
         if (limitInMB <= 0) {
             LogPrintf("Failed to understand blocksizeacceptlimit: '%s'\n", userlimit->second.c_str());
         } else {
-            limit = static_cast<int32_t>(limitInMB * 10) * 1E5;
+            limit = static_cast<int32_t>(round(limitInMB * 1000000));
+            limit -= (limit % 100000); // only one digit behind the dot was allowed
         }
     }
     if (limit <= 0)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -161,8 +161,10 @@ int32_t Policy::blockSizeAcceptLimit()
 {
     int limit = -1;
     auto userlimit = mapArgs.find("-blocksizeacceptlimit");
-    if (userlimit == mapArgs.end()) { // fallback to the BitcoinUnlimited name.
-       limit = GetArg("-excessiveblocksize", -1);
+    if (userlimit == mapArgs.end()) {
+        limit = GetArg("-blocksizeacceptlimitbytes", -1);
+        if (limit == -1) // fallback to the BitcoinUnlimited name.
+           limit = GetArg("-excessiveblocksize", -1);
     }
     else {
         // this is in fractions of a megabyte (for instance "3.2")
@@ -175,7 +177,7 @@ int32_t Policy::blockSizeAcceptLimit()
         }
     }
     if (limit <= 0)
-        limit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
+        limit = DEFAULT_BLOCK_ACCEPT_SIZE;
     if (limit < 1000000)
         LogPrintf("BlockSize set to extremely low value (%d bytes), this may cause failures.\n", limit);
     return limit;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -29,7 +29,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -blocksizeacceptlimit */
-static const float DEFAULT_BLOCK_ACCEPT_SIZE = 2.;
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 3.7;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Default for -bytespersigop */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -15,7 +15,7 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2E6;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
@@ -28,6 +28,8 @@ static const unsigned int MAX_P2SH_SIGOPS = 15;
 static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
+/** Default for -blocksizeacceptlimit */
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 2.;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Default for -bytespersigop */
@@ -84,6 +86,11 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
      * @return True if all inputs (scriptSigs) use only standard transaction forms
      */
 bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+
+namespace Policy {
+  std::int32_t blockSizeAcceptLimit();
+}
+
     /**
      * Check if the transaction is over standard P2WSH resources limit:
      * 3600bytes witnessScript size, 80bytes per witness stack element, 100 witness stack elements

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -29,7 +29,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -blocksizeacceptlimit */
-static const float DEFAULT_BLOCK_ACCEPT_SIZE = 3.7;
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 3.7e6;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Default for -bytespersigop */

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -215,7 +215,7 @@ QString ClientModel::formatFullVersion() const
 
 QString ClientModel::formatSubVersion() const
 {
-    return QString::fromStdString(strSubVersion);
+    return QString::fromStdString(FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, 0));
 }
 
 bool ClientModel::isReleaseVersion() const

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -118,6 +118,62 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4_Main">
+         <item>
+          <widget class="QLabel" name="blockSizeAcceptLimitLabel">
+           <property name="text">
+            <string>&amp;Block size accept limit</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>blockSizeAcceptLimit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="blockSizeAcceptLimit">
+            <property name="toolTip">
+             <string>This node will not accept blocks larger than this limit.</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>2147</number>
+            </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="blockSizeAcceptLimitUnitLabel">
+           <property name="text">
+            <string>MB</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4_Main">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Main">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -762,7 +762,7 @@
           <item>
            <widget class="QLabel" name="fallbackFeeWarningLabel">
             <property name="toolTip">
-             <string>Using the fallbackfee can result in sending a transaction that will take serval hours or days (or never) to confirm. Consider choosing your fee manually or wait until your have validated the complete chain.</string>
+             <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until your have validated the complete chain.</string>
             </property>
             <property name="font">
             <font>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -162,6 +162,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     /* Main */
     connect(ui->databaseCache, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     connect(ui->threadsScriptVerif, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
+    connect(ui->blockSizeAcceptLimit, SIGNAL(valueChanged(double)), this, SLOT(showRestartWarning()));
     /* Wallet */
     connect(ui->spendZeroConfChange, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
     /* Network */
@@ -179,6 +180,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->bitcoinAtStartup, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
     mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
+    mapper->addMapping(ui->blockSizeAcceptLimit, OptionsModel::BlockSizeAcceptLimit);
 
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -105,11 +105,11 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("strDataDir", Intro::getDefaultDataDirectory());
     if (!settings.contains("blockSizeAcceptLimitBytes"))
         settings.setValue("blockSizeAcceptLimitBytes", DEFAULT_BLOCK_ACCEPT_SIZE);
-    if (mapArgs.count("-blocksizeacceptlimit"))
+    if (!GetArg("-blocksizeacceptlimit", "").empty())
         addOverriddenOption("-blocksizeacceptlimit");
-    else if (mapArgs.count("-blocksizeacceptlimitbytes"))
+    else if (!GetArg("-blocksizeacceptlimitbytes", "").empty())
         addOverriddenOption("-blocksizeacceptlimitbytes");
-    else if (mapArgs.count("-excessiveblocksize"))
+    else if (!GetArg("-excessiveblocksize", "").empty())
         addOverriddenOption("-excessiveblocksize");
     else
         SoftSetArg("-blocksizeacceptlimitbytes", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -18,6 +18,7 @@
 #include "netbase.h"
 #include "txdb.h" // for -dbcache defaults
 #include "intro.h" 
+#include "policy/policy.h" // for DEFAULT_BLOCK_ACCEPT_SIZE
 
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
@@ -102,6 +103,14 @@ void OptionsModel::Init(bool resetSettings)
 
     if (!settings.contains("strDataDir"))
         settings.setValue("strDataDir", Intro::getDefaultDataDirectory());
+    if (!settings.contains("blockSizeAcceptLimitBytes"))
+        settings.setValue("blockSizeAcceptLimitBytes", static_cast<int32_t>(round(DEFAULT_BLOCK_ACCEPT_SIZE * 1e6)));
+    if (mapArgs.count("-blocksizeacceptlimit"))
+        addOverriddenOption("-blocksizeacceptlimit");
+    else if (mapArgs.count("-excessiveblocksize"))
+        addOverriddenOption("-excessiveblocksize");
+    else
+        SoftSetArg("-excessiveblocksize", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());
 
     // Wallet
 #ifdef ENABLE_WALLET
@@ -247,6 +256,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("nThreadsScriptVerif");
         case Listen:
             return settings.value("fListen");
+        case BlockSizeAcceptLimit:
+            return settings.value("blockSizeAcceptLimitBytes").toInt() / 1e6;
         default:
             return QVariant();
         }
@@ -393,6 +404,14 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (settings.value("fListen") != value) {
                 settings.setValue("fListen", value);
                 setRestartRequired(true);
+            }
+            break;
+        case BlockSizeAcceptLimit: {
+                int32_t valueBytes = round(value.toDouble() * 1e6);
+                if (settings.value("blockSizeAcceptLimitBytes") != valueBytes) {
+                    settings.setValue("blockSizeAcceptLimitBytes", valueBytes);
+                    setRestartRequired(true);
+                }
             }
             break;
         default:

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -104,13 +104,15 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("strDataDir"))
         settings.setValue("strDataDir", Intro::getDefaultDataDirectory());
     if (!settings.contains("blockSizeAcceptLimitBytes"))
-        settings.setValue("blockSizeAcceptLimitBytes", static_cast<int32_t>(round(DEFAULT_BLOCK_ACCEPT_SIZE * 1e6)));
+        settings.setValue("blockSizeAcceptLimitBytes", DEFAULT_BLOCK_ACCEPT_SIZE);
     if (mapArgs.count("-blocksizeacceptlimit"))
         addOverriddenOption("-blocksizeacceptlimit");
+    else if (mapArgs.count("-blocksizeacceptlimitbytes"))
+        addOverriddenOption("-blocksizeacceptlimitbytes");
     else if (mapArgs.count("-excessiveblocksize"))
         addOverriddenOption("-excessiveblocksize");
     else
-        SoftSetArg("-excessiveblocksize", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());
+        SoftSetArg("-blocksizeacceptlimitbytes", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());
 
     // Wallet
 #ifdef ENABLE_WALLET

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -46,6 +46,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         Listen,                 // bool
+        BlockSizeAcceptLimit,   // double
         OptionIDRowCount,
     };
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -377,7 +377,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             "  ],\n"
             "  \"noncerange\" : \"00000000ffffffff\",(string) A range of valid nonces\n"
             "  \"sigoplimit\" : n,                 (numeric) limit of sigops in blocks\n"
-            "  \"sizelimit\" : n,                  (numeric) limit of block size\n"
+            "  \"sizelimit\" : n,                  (numeric) limit of block size. (deprecated)\n"
             "  \"weightlimit\" : n,                (numeric) limit of block weight\n"
             "  \"curtime\" : ttt,                  (numeric) current timestamp in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"bits\" : \"xxxxxxxx\",              (string) compressed target of next block\n"
@@ -599,9 +599,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         transactions.push_back(entry);
     }
 
-    UniValue aux(UniValue::VOBJ);
-    aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
-
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
     UniValue aMutable(UniValue::VARR);
@@ -669,7 +666,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
 
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
-    result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue));
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));
@@ -683,7 +679,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     }
     result.push_back(Pair("sigoplimit", nSigOpLimit));
     if (fPreSegWit) {
-        result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_BASE_SIZE));
+        int64_t sizeLimit = 32E6; // lets have a nice big default, the goal is to remove this from the API
+        result.push_back(Pair("sizelimit", sizeLimit));
     } else {
         result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SERIALIZED_SIZE));
         result.push_back(Pair("weightlimit", (int64_t)MAX_BLOCK_WEIGHT));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -435,7 +435,8 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
     LOCK(cs_main);
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("version",       CLIENT_VERSION));
-    obj.push_back(Pair("subversion",    strSubVersion));
+    obj.push_back(Pair("subversion",
+        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, 0)));
     obj.push_back(Pair("protocolversion",PROTOCOL_VERSION));
     if(g_connman)
         obj.push_back(Pair("localservices", strprintf("%016x", g_connman->GetLocalServices())));

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "util.h"
 #include "test/test_bitcoin.h"
+#include <policy/policy.h>
 
 #include <string>
 #include <vector>
@@ -157,6 +158,22 @@ BOOST_AUTO_TEST_CASE(boolargno)
     ResetArgs("-nofoo -foo"); // foo always wins:
     BOOST_CHECK(GetBoolArg("-foo", true));
     BOOST_CHECK(GetBoolArg("-foo", false));
+}
+
+BOOST_AUTO_TEST_CASE(blockSizeAcceptLimit)
+{
+    ResetArgs("-excessiveblocksize=5004000");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
+
+    // blocksizeacceptlimit always wins
+    ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimit=1.2");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    ResetArgs("-blocksizeacceptlimit=1.2");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    ResetArgs("-blocksizeacceptlimit=1.25");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -165,9 +165,20 @@ BOOST_AUTO_TEST_CASE(blockSizeAcceptLimit)
     ResetArgs("-excessiveblocksize=5004000");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
 
+    ResetArgs("-blocksizeacceptlimitbytes=5004000");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
+
     // blocksizeacceptlimit always wins
     ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimit=1.2");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    // blocksizeacceptlimit always wins
+    ResetArgs("-blocksizeacceptlimitbytes=5004000 -blocksizeacceptlimit=1.2");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    // blocksizeacceptlimitbytes always wins
+    ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimitbytes=6004000");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 6004000);
 
     ResetArgs("-blocksizeacceptlimit=1.2");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -496,9 +496,9 @@ BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
     std::vector<std::string> comments2;
     comments2.push_back(std::string("comment1"));
     comments2.push_back(SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)); // Semicolon is discouraged but not forbidden by BIP-0014
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:0.9.99/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:0.9.99(comment1)/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>(), 0),std::string("/Test:0.9.99/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments, 0),std::string("/Test:0.9.99(comment1)/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2, 0),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -24,6 +24,7 @@ static const char DB_FLAG = 'F';
 static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
 
+static const char DB_SIZE_REMOVAL_FORK_ACTIVATION = 's';
 
 CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true) 
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1279,10 +1279,13 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
       log(pindexNew->nChainWork.getdouble())/log(2.0), DateTimeStrFormat("%Y-%m-%d %H:%M:%S",
       pindexNew->GetBlockTime()));
     CBlockIndex *tip = chainActive.Tip();
-    assert (tip);
-    LogPrintf("%s:  current best=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
-      tip->GetBlockHash().ToString(), chainActive.Height(), log(tip->nChainWork.getdouble())/log(2.0),
-      DateTimeStrFormat("%Y-%m-%d %H:%M:%S", tip->GetBlockTime()));
+    if (tip) {
+        LogPrintf("%s:  current best=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
+          tip->GetBlockHash().ToString(), chainActive.Height(), log(tip->nChainWork.getdouble())/log(2.0),
+          DateTimeStrFormat("%Y-%m-%d %H:%M:%S", tip->GetBlockTime()));
+    } else {
+        LogPrintf("%s:  Genesis rejected. This will not end well.\n", __func__);
+    }
     CheckForkWarningConditions();
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2845,7 +2845,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // checks that use witness data may be performed here.
 
     // Size limits
-    if (block.vtx.empty() || block.vtx.size() > MAX_BLOCK_BASE_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > MAX_BLOCK_BASE_SIZE)
+    std::int32_t nSizeLimit = Policy::blockSizeAcceptLimit();
+    if (block.vtx.empty() || block.vtx.size() > (uint32_t) nSizeLimit || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > (uint32_t) nSizeLimit)
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-length", false, "size limits failed");
 
     // First transaction must be coinbase, the rest must not be
@@ -3845,7 +3846,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
     int nLoaded = 0;
     try {
         // This takes over fileIn and calls fclose() on it in the CBufferedFile destructor
-        CBufferedFile blkdat(fileIn, 2*MAX_BLOCK_SERIALIZED_SIZE, MAX_BLOCK_SERIALIZED_SIZE+8, SER_DISK, CLIENT_VERSION);
+        CBufferedFile blkdat(fileIn, 2E6, 1E6+8, SER_DISK, CLIENT_VERSION);
         uint64_t nRewind = blkdat.GetPos();
         while (!blkdat.eof()) {
             boost::this_thread::interruption_point();
@@ -3864,7 +3865,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                     continue;
                 // read size
                 blkdat >> nSize;
-                if (nSize < 80 || nSize > MAX_BLOCK_SERIALIZED_SIZE)
+                if (nSize < 80)
                     continue;
             } catch (const std::exception&) {
                 // no valid block header found; don't complain

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -725,6 +725,7 @@ public:
         nLastResend = 0;
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
+        nRelockTime = 0;
     }
 
     std::map<uint256, CWalletTx> mapWallet;


### PR DESCRIPTION
Hey there,

I made this mostly for myself, because I was sick of people telling me I am a terrorist
for running BU or that I am trying to destroy Bitcoin... But your repo looked empty, maybe you also want it?

This is the user configurable blocksize setting from bitcoin classic, the clientversion
stuff comes from the [bip100 pull request](https://github.com/bitcoinxt/bitcoin/pull/1), because somehow classic changed
a lot there and has a new file Application.cpp I could not figure out how to do this myself :).

And in the bip100 PR it defaulted to 64bit int, but the classic stuff has 32bit int, so I changed it also to 32bit. This should still be plenty enough blockspace for now...

So far it seems to work fine, compiles and runs, it shows the EB value in useragent on a different node if I call `getpeerinfo`. I also mined a few blocks in `-regtest` mode and they seem to contain the EB value.
But I have not actually tried to create >1MB blocks yet, this surely needs some review and testing.

Also there are like 2 cosmetic errors: I could not figure out where to place
`std::vector<unsigned char> m_coinbaseComment;` in miner.h, it either failed with not declared errors or it seemed to declare it multiple times somehow, not sure what I was doing wrong there. So I just placed it at the top of miner.cpp ... Also apparently while trying around with this by accident I deleted a whitespace in miner.h (oh well).

Right now the PR shows a few extra commits from core, because my repo is some commits ahead. It should only show my commits, if you do a `git pull` & `git push` first.

greetings from the core-bitcoin (lol)