### PR TITLE
user configurable blocksize setting from bitcoin classic

### DIFF
--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -25,6 +25,8 @@ We use the testing framework in which we expect a particular answer from
 each test.
 '''
 
+MAX_BLOCK_BASE_SIZE = 1000000
+
 #  Use this class for tests that require behavior other than normal "mininode" behavior.
 #  For now, it is used to serialize a bloated varint (b64).
 class CBrokenBlock(CBlock):
@@ -61,6 +63,11 @@ class FullBlockTest(ComparisonTestFramework):
         self.coinbase_pubkey = self.coinbase_key.get_pubkey()
         self.tip = None
         self.blocks = {}
+
+    def setup_nodes(self):
+        return start_nodes(4, self.options.tmpdir,
+                extra_args = [["-maxblocksize=1000000", "--blocksizeacceptlimit=1"]])
+
 
     def add_options(self, parser):
         super().add_options(parser)
@@ -377,7 +384,7 @@ class FullBlockTest(ComparisonTestFramework):
         tx.vout = [CTxOut(0, script_output)]
         b24 = update_block(24, [tx])
         assert_equal(len(b24.serialize()), MAX_BLOCK_BASE_SIZE+1)
-        yield rejected(RejectResult(16, b'bad-blk-length'))
+        yield rejected()
 
         block(25, spend=out[7])
         yield rejected()

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -9,7 +9,9 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.mininode import COIN, MAX_BLOCK_BASE_SIZE
+from test_framework.mininode import COIN
+
+MAX_BLOCK_BASE_SIZE = 1000000
 
 class PrioritiseTransactionTest(BitcoinTestFramework):
 
@@ -24,7 +26,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.nodes = []
         self.is_network_split = False
 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-printpriority=1"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-printpriority=1", "--blocksizeacceptlimit=1"]))
         self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 
     def run_test(self):

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -44,7 +44,6 @@ MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
 MAX_INV_SZ = 50000
-MAX_BLOCK_BASE_SIZE = 1000000
 
 COIN = 100000000 # 1 btc in satoshis
 

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -88,12 +88,12 @@ std::string FormatFullVersion()
 /** 
  * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) 
  */
-std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit)
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nMaxBlockSize)
 {
-    if (nSizeLimit) {
+    if (nMaxBlockSize) {
         // Announce our excessive block acceptence.
         std::stringstream ss;
-        double dMaxBlockSize = static_cast<double>(nSizeLimit) / 1000000;
+        double dMaxBlockSize = static_cast<double>(nMaxBlockSize) / 1000000;
         ss << "EB" << std::setprecision(static_cast<int>(std::log10(dMaxBlockSize))+7) << dMaxBlockSize;
         comments.insert(comments.end(), ss.str());
     }

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -5,8 +5,11 @@
 #include "clientversion.h"
 
 #include "tinyformat.h"
+#include "policy/policy.h"
 
 #include <string>
+#include <iomanip>
+#include <cmath>
 
 /**
  * Name of client reported in the 'version' message. Report the same name
@@ -85,8 +88,16 @@ std::string FormatFullVersion()
 /** 
  * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) 
  */
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit)
 {
+    if (nSizeLimit) {
+        // Announce our excessive block acceptence.
+        std::stringstream ss;
+        double dMaxBlockSize = static_cast<double>(nSizeLimit) / 1000000;
+        ss << "EB" << std::setprecision(static_cast<int>(std::log10(dMaxBlockSize))+7) << dMaxBlockSize;
+        comments.insert(comments.end(), ss.str());
+    }
+
     std::ostringstream ss;
     ss << "/";
     ss << name << ":" << FormatVersion(nClientVersion);

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -62,7 +62,7 @@ extern const std::string CLIENT_BUILD;
 
 
 std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit);
 
 #endif // WINDRES_PREPROC
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -63,7 +63,7 @@ extern const std::string CLIENT_BUILD;
 
 
 std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nSizeLimit);
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint32_t nMaxBlockSize);
 
 #endif // WINDRES_PREPROC
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -50,6 +50,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 static const int CLIENT_VERSION =
                            1000000 * CLIENT_VERSION_MAJOR

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -475,6 +475,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE));
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
@@ -1233,10 +1234,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             uacomments.push_back(cmt);
         }
     }
-    strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments);
-    if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
+    std::int32_t BlockSizeLimit = Policy::blockSizeAcceptLimit(); 
+    size_t userAgentLen = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments, BlockSizeLimit).size();
+    if (userAgentLen > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
-            strSubVersion.size(), MAX_SUBVERSION_LENGTH));
+            userAgentLen, MAX_SUBVERSION_LENGTH));
     }
 
     if (mapMultiArgs.count("-onlynet")) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -475,7 +475,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
-    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE));
+    strUsage += HelpMessageOpt("-blocksizeacceptlimit=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in MB (default: %.1f)", DEFAULT_BLOCK_ACCEPT_SIZE / 1e6));
+    strUsage += HelpMessageOpt("-blocksizeacceptlimitbytes,excessiveblocksize=<n>", strprintf("This node will not accept blocks larger than this limit. Unit is in bytes. Superseded by -blocksizeacceptlimit (default: %u)", DEFAULT_BLOCK_ACCEPT_SIZE));
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1225,17 +1225,16 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     RegisterNodeSignals(GetNodeSignals());
 
     // sanitize comments per BIP-0014, format user agent and check total size
-    std::vector<std::string> uacomments;
     if (mapMultiArgs.count("-uacomment")) {
         BOOST_FOREACH(std::string cmt, mapMultiArgs.at("-uacomment"))
         {
             if (cmt != SanitizeString(cmt, SAFE_CHARS_UA_COMMENT))
                 return InitError(strprintf(_("User Agent comment (%s) contains unsafe characters."), cmt));
-            uacomments.push_back(cmt);
+            vUAComments.push_back(cmt);
         }
     }
     std::int32_t BlockSizeLimit = Policy::blockSizeAcceptLimit(); 
-    size_t userAgentLen = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments, BlockSizeLimit).size();
+    size_t userAgentLen = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, BlockSizeLimit).size();
     if (userAgentLen > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
             userAgentLen, MAX_SUBVERSION_LENGTH));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -31,6 +31,9 @@
 #include <queue>
 #include <utility>
 
+//FIXME
+std::vector<unsigned char> m_coinbaseComment;
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // BitcoinMiner
@@ -181,7 +184,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
     coinbaseTx.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
-    coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
+    coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0 << m_coinbaseComment;
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
     pblocktemplate->vchCoinbaseCommitment = GenerateCoinbaseCommitment(*pblock, pindexPrev, chainparams.GetConsensus());
     pblocktemplate->vTxFees[0] = -nFees;
@@ -606,9 +609,21 @@ void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned
     ++nExtraNonce;
     unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
-    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) + COINBASE_FLAGS;
+    txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) << m_coinbaseComment;
     assert(txCoinbase.vin[0].scriptSig.size() <= 100);
 
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+
+    // read args to create m_coinbaseComment
+    std::int32_t sizeLimit = Policy::blockSizeAcceptLimit();
+
+    std::stringstream ss;
+    ss << std::fixed;
+    if ((sizeLimit % 1000000) != 0)
+      ss << std::setprecision(1) << sizeLimit / 1E6;
+    else
+      ss << (int) (sizeLimit / 1E6);
+    std::string comment = "EB" + ss.str();
+    m_coinbaseComment =  std::vector<unsigned char>(comment.begin(), comment.end());
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -72,7 +72,7 @@ bool fRelayTxes = true;
 CCriticalSection cs_mapLocalHost;
 std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};
-std::string strSubVersion;
+std::vector<std::string> vUAComments;
 
 limitedmap<uint256, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
 

--- a/src/net.h
+++ b/src/net.h
@@ -471,8 +471,8 @@ extern bool fRelayTxes;
 
 extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
 
-/** Subversion as sent to the P2P network in `version` messages */
-extern std::string strSubVersion;
+/** Comments in subversion as sent to the P2P network in `version` messages */
+extern std::vector<std::string> vUAComments;
 
 struct LocalServiceInfo {
     int nScore;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -9,6 +9,7 @@
 #include "arith_uint256.h"
 #include "blockencodings.h"
 #include "chainparams.h"
+#include "clientversion.h"
 #include "consensus/validation.h"
 #include "hash.h"
 #include "init.h"
@@ -247,12 +248,14 @@ void PushNodeVersion(CNode *pnode, CConnman& connman, int64_t nTime)
     ServiceFlags nLocalNodeServices = pnode->GetLocalServices();
     uint64_t nonce = pnode->GetLocalNonce();
     int nNodeStartingHeight = pnode->GetMyStartingHeight();
+    std::int32_t nMaxBlockSize = Policy::blockSizeAcceptLimit();
     NodeId nodeid = pnode->GetId();
     CAddress addr = pnode->addr;
 
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService(), addr.nServices));
     CAddress addrMe = CAddress(CService(), nLocalNodeServices);
 
+    std::string strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, nMaxBlockSize);
     connman.PushMessage(pnode, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERSION, PROTOCOL_VERSION, (uint64_t)nLocalNodeServices, nTime, addrYou, addrMe,
             nonce, strSubVersion, nNodeStartingHeight, ::fRelayTxes));
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -158,11 +158,13 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
 int32_t Policy::blockSizeAcceptLimit()
 {
-    auto limit = -1;
+    int limit = -1;
     auto userlimit = mapArgs.find("-blocksizeacceptlimit");
-    if (userlimit == mapArgs.end()) // fallback to the BitcoinUnlimited name.
-       userlimit = mapArgs.find("-excessiveblocksize");
-    if (userlimit != mapArgs.end()) {
+    if (userlimit == mapArgs.end()) { // fallback to the BitcoinUnlimited name.
+       limit = GetArg("-excessiveblocksize", -1);
+    }
+    else {
+        // this is in fractions of a megabyte (for instance "3.2")
         double limitInMB = atof(userlimit->second.c_str());
         if (limitInMB <= 0) {
             LogPrintf("Failed to understand blocksizeacceptlimit: '%s'\n", userlimit->second.c_str());

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -176,6 +176,8 @@ int32_t Policy::blockSizeAcceptLimit()
     }
     if (limit <= 0)
         limit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
+    if (limit < 1000000)
+        LogPrintf("BlockSize set to extremely low value (%d bytes), this may cause failures.\n", limit);
     return limit;
 }
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/foreach.hpp>
 
+extern std::map<std::string, std::string> mapArgs;
+
     /**
      * Check transaction inputs to mitigate two
      * potential denial-of-service attacks:
@@ -152,6 +154,25 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     }
 
     return true;
+}
+
+int32_t Policy::blockSizeAcceptLimit()
+{
+    auto limit = -1;
+    auto userlimit = mapArgs.find("-blocksizeacceptlimit");
+    if (userlimit == mapArgs.end()) // fallback to the BitcoinUnlimited name.
+       userlimit = mapArgs.find("-excessiveblocksize");
+    if (userlimit != mapArgs.end()) {
+        double limitInMB = atof(userlimit->second.c_str());
+        if (limitInMB <= 0) {
+            LogPrintf("Failed to understand blocksizeacceptlimit: '%s'\n", userlimit->second.c_str());
+        } else {
+            limit = static_cast<int32_t>(limitInMB * 10) * 1E5;
+        }
+    }
+    if (limit <= 0)
+        limit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
+    return limit;
 }
 
 bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -12,6 +12,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
+#include <cmath>
 #include <boost/foreach.hpp>
 
 extern std::map<std::string, std::string> mapArgs;
@@ -169,7 +170,8 @@ int32_t Policy::blockSizeAcceptLimit()
         if (limitInMB <= 0) {
             LogPrintf("Failed to understand blocksizeacceptlimit: '%s'\n", userlimit->second.c_str());
         } else {
-            limit = static_cast<int32_t>(limitInMB * 10) * 1E5;
+            limit = static_cast<int32_t>(round(limitInMB * 1000000));
+            limit -= (limit % 100000); // only one digit behind the dot was allowed
         }
     }
     if (limit <= 0)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -161,8 +161,10 @@ int32_t Policy::blockSizeAcceptLimit()
 {
     int limit = -1;
     auto userlimit = mapArgs.find("-blocksizeacceptlimit");
-    if (userlimit == mapArgs.end()) { // fallback to the BitcoinUnlimited name.
-       limit = GetArg("-excessiveblocksize", -1);
+    if (userlimit == mapArgs.end()) {
+        limit = GetArg("-blocksizeacceptlimitbytes", -1);
+        if (limit == -1) // fallback to the BitcoinUnlimited name.
+           limit = GetArg("-excessiveblocksize", -1);
     }
     else {
         // this is in fractions of a megabyte (for instance "3.2")
@@ -175,7 +177,7 @@ int32_t Policy::blockSizeAcceptLimit()
         }
     }
     if (limit <= 0)
-        limit = static_cast<int32_t>(DEFAULT_BLOCK_ACCEPT_SIZE * 10) * 1E5;
+        limit = DEFAULT_BLOCK_ACCEPT_SIZE;
     if (limit < 1000000)
         LogPrintf("BlockSize set to extremely low value (%d bytes), this may cause failures.\n", limit);
     return limit;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -15,7 +15,7 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2E6;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
@@ -30,6 +30,8 @@ static const unsigned int MAX_P2SH_SIGOPS = 15;
 static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
+/** Default for -blocksizeacceptlimit */
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 2.;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Default for -bytespersigop */
@@ -86,6 +88,11 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
      * @return True if all inputs (scriptSigs) use only standard transaction forms
      */
 bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs);
+
+namespace Policy {
+  std::int32_t blockSizeAcceptLimit();
+}
+
     /**
      * Check if the transaction is over standard P2WSH resources limit:
      * 3600bytes witnessScript size, 80bytes per witness stack element, 100 witness stack elements

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -31,7 +31,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -blocksizeacceptlimit */
-static const float DEFAULT_BLOCK_ACCEPT_SIZE = 2.;
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 3.7;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Default for -bytespersigop */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -31,7 +31,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -blocksizeacceptlimit */
-static const float DEFAULT_BLOCK_ACCEPT_SIZE = 3.7;
+static const float DEFAULT_BLOCK_ACCEPT_SIZE = 3.7e6;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Default for -bytespersigop */

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -215,7 +215,7 @@ QString ClientModel::formatFullVersion() const
 
 QString ClientModel::formatSubVersion() const
 {
-    return QString::fromStdString(strSubVersion);
+    return QString::fromStdString(FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, 0));
 }
 
 bool ClientModel::isReleaseVersion() const

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -118,6 +118,62 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4_Main">
+         <item>
+          <widget class="QLabel" name="blockSizeAcceptLimitLabel">
+           <property name="text">
+            <string>&amp;Block size accept limit</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>blockSizeAcceptLimit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="blockSizeAcceptLimit">
+            <property name="toolTip">
+             <string>This node will not accept blocks larger than this limit.</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>2147</number>
+            </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="blockSizeAcceptLimitUnitLabel">
+           <property name="text">
+            <string>MB</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4_Main">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Main">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -162,6 +162,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     /* Main */
     connect(ui->databaseCache, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     connect(ui->threadsScriptVerif, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
+    connect(ui->blockSizeAcceptLimit, SIGNAL(valueChanged(double)), this, SLOT(showRestartWarning()));
     /* Wallet */
     connect(ui->spendZeroConfChange, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
     /* Network */
@@ -179,6 +180,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->bitcoinAtStartup, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
     mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
+    mapper->addMapping(ui->blockSizeAcceptLimit, OptionsModel::BlockSizeAcceptLimit);
 
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -105,11 +105,11 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("strDataDir", Intro::getDefaultDataDirectory());
     if (!settings.contains("blockSizeAcceptLimitBytes"))
         settings.setValue("blockSizeAcceptLimitBytes", DEFAULT_BLOCK_ACCEPT_SIZE);
-    if (mapArgs.count("-blocksizeacceptlimit"))
+    if (!GetArg("-blocksizeacceptlimit", "").empty())
         addOverriddenOption("-blocksizeacceptlimit");
-    else if (mapArgs.count("-blocksizeacceptlimitbytes"))
+    else if (!GetArg("-blocksizeacceptlimitbytes", "").empty())
         addOverriddenOption("-blocksizeacceptlimitbytes");
-    else if (mapArgs.count("-excessiveblocksize"))
+    else if (!GetArg("-excessiveblocksize", "").empty())
         addOverriddenOption("-excessiveblocksize");
     else
         SoftSetArg("-blocksizeacceptlimitbytes", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -18,6 +18,7 @@
 #include "netbase.h"
 #include "txdb.h" // for -dbcache defaults
 #include "intro.h" 
+#include "policy/policy.h" // for DEFAULT_BLOCK_ACCEPT_SIZE
 
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
@@ -102,6 +103,14 @@ void OptionsModel::Init(bool resetSettings)
 
     if (!settings.contains("strDataDir"))
         settings.setValue("strDataDir", Intro::getDefaultDataDirectory());
+    if (!settings.contains("blockSizeAcceptLimitBytes"))
+        settings.setValue("blockSizeAcceptLimitBytes", static_cast<int32_t>(round(DEFAULT_BLOCK_ACCEPT_SIZE * 1e6)));
+    if (mapArgs.count("-blocksizeacceptlimit"))
+        addOverriddenOption("-blocksizeacceptlimit");
+    else if (mapArgs.count("-excessiveblocksize"))
+        addOverriddenOption("-excessiveblocksize");
+    else
+        SoftSetArg("-excessiveblocksize", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());
 
     // Wallet
 #ifdef ENABLE_WALLET
@@ -247,6 +256,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("nThreadsScriptVerif");
         case Listen:
             return settings.value("fListen");
+        case BlockSizeAcceptLimit:
+            return settings.value("blockSizeAcceptLimitBytes").toInt() / 1e6;
         default:
             return QVariant();
         }
@@ -393,6 +404,14 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (settings.value("fListen") != value) {
                 settings.setValue("fListen", value);
                 setRestartRequired(true);
+            }
+            break;
+        case BlockSizeAcceptLimit: {
+                int32_t valueBytes = round(value.toDouble() * 1e6);
+                if (settings.value("blockSizeAcceptLimitBytes") != valueBytes) {
+                    settings.setValue("blockSizeAcceptLimitBytes", valueBytes);
+                    setRestartRequired(true);
+                }
             }
             break;
         default:

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -104,13 +104,15 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("strDataDir"))
         settings.setValue("strDataDir", Intro::getDefaultDataDirectory());
     if (!settings.contains("blockSizeAcceptLimitBytes"))
-        settings.setValue("blockSizeAcceptLimitBytes", static_cast<int32_t>(round(DEFAULT_BLOCK_ACCEPT_SIZE * 1e6)));
+        settings.setValue("blockSizeAcceptLimitBytes", DEFAULT_BLOCK_ACCEPT_SIZE);
     if (mapArgs.count("-blocksizeacceptlimit"))
         addOverriddenOption("-blocksizeacceptlimit");
+    else if (mapArgs.count("-blocksizeacceptlimitbytes"))
+        addOverriddenOption("-blocksizeacceptlimitbytes");
     else if (mapArgs.count("-excessiveblocksize"))
         addOverriddenOption("-excessiveblocksize");
     else
-        SoftSetArg("-excessiveblocksize", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());
+        SoftSetArg("-blocksizeacceptlimitbytes", settings.value("blockSizeAcceptLimitBytes").toString().toStdString());
 
     // Wallet
 #ifdef ENABLE_WALLET

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -46,6 +46,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         Listen,                 // bool
+        BlockSizeAcceptLimit,   // double
         OptionIDRowCount,
     };
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -382,7 +382,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             "  ],\n"
             "  \"noncerange\" : \"00000000ffffffff\",(string) A range of valid nonces\n"
             "  \"sigoplimit\" : n,                 (numeric) limit of sigops in blocks\n"
-            "  \"sizelimit\" : n,                  (numeric) limit of block size\n"
+            "  \"sizelimit\" : n,                  (numeric) limit of block size. (deprecated)\n"
             "  \"weightlimit\" : n,                (numeric) limit of block weight\n"
             "  \"curtime\" : ttt,                  (numeric) current timestamp in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"bits\" : \"xxxxxxxx\",              (string) compressed target of next block\n"
@@ -593,9 +593,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         transactions.push_back(entry);
     }
 
-    UniValue aux(UniValue::VOBJ);
-    aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
-
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
     UniValue aMutable(UniValue::VARR);
@@ -663,7 +660,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
 
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
-    result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue));
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));
@@ -677,7 +673,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     }
     result.push_back(Pair("sigoplimit", nSigOpLimit));
     if (fPreSegWit) {
-        result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_BASE_SIZE));
+        int64_t sizeLimit = 32E6; // lets have a nice big default, the goal is to remove this from the API
+        result.push_back(Pair("sizelimit", sizeLimit));
     } else {
         result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SERIALIZED_SIZE));
         result.push_back(Pair("weightlimit", (int64_t)MAX_BLOCK_WEIGHT));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -437,7 +437,8 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
     LOCK(cs_main);
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("version",       CLIENT_VERSION));
-    obj.push_back(Pair("subversion",    strSubVersion));
+    obj.push_back(Pair("subversion",
+        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, 0)));
     obj.push_back(Pair("protocolversion",PROTOCOL_VERSION));
     if(g_connman)
         obj.push_back(Pair("localservices", strprintf("%016x", g_connman->GetLocalServices())));

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "util.h"
 #include "test/test_bitcoin.h"
+#include <policy/policy.h>
 
 #include <string>
 #include <vector>
@@ -157,6 +158,22 @@ BOOST_AUTO_TEST_CASE(boolargno)
     ResetArgs("-nofoo -foo"); // foo always wins:
     BOOST_CHECK(GetBoolArg("-foo", true));
     BOOST_CHECK(GetBoolArg("-foo", false));
+}
+
+BOOST_AUTO_TEST_CASE(blockSizeAcceptLimit)
+{
+    ResetArgs("-excessiveblocksize=5004000");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
+
+    // blocksizeacceptlimit always wins
+    ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimit=1.2");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    ResetArgs("-blocksizeacceptlimit=1.2");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    ResetArgs("-blocksizeacceptlimit=1.25");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -165,9 +165,20 @@ BOOST_AUTO_TEST_CASE(blockSizeAcceptLimit)
     ResetArgs("-excessiveblocksize=5004000");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
 
+    ResetArgs("-blocksizeacceptlimitbytes=5004000");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 5004000);
+
     // blocksizeacceptlimit always wins
     ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimit=1.2");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    // blocksizeacceptlimit always wins
+    ResetArgs("-blocksizeacceptlimitbytes=5004000 -blocksizeacceptlimit=1.2");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);
+
+    // blocksizeacceptlimitbytes always wins
+    ResetArgs("-excessiveblocksize=5004000 -blocksizeacceptlimitbytes=6004000");
+    BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 6004000);
 
     ResetArgs("-blocksizeacceptlimit=1.2");
     BOOST_CHECK_EQUAL(Policy::blockSizeAcceptLimit(), 1200000);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -496,9 +496,9 @@ BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
     std::vector<std::string> comments2;
     comments2.push_back(std::string("comment1"));
     comments2.push_back(SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)); // Semicolon is discouraged but not forbidden by BIP-0014
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:0.9.99/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:0.9.99(comment1)/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>(), 0),std::string("/Test:0.9.99/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments, 0),std::string("/Test:0.9.99(comment1)/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2, 0),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1304,10 +1304,13 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
       log(pindexNew->nChainWork.getdouble())/log(2.0), DateTimeStrFormat("%Y-%m-%d %H:%M:%S",
       pindexNew->GetBlockTime()));
     CBlockIndex *tip = chainActive.Tip();
-    assert (tip);
-    LogPrintf("%s:  current best=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
-      tip->GetBlockHash().ToString(), chainActive.Height(), log(tip->nChainWork.getdouble())/log(2.0),
-      DateTimeStrFormat("%Y-%m-%d %H:%M:%S", tip->GetBlockTime()));
+    if (tip) {
+        LogPrintf("%s:  current best=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
+          tip->GetBlockHash().ToString(), chainActive.Height(), log(tip->nChainWork.getdouble())/log(2.0),
+          DateTimeStrFormat("%Y-%m-%d %H:%M:%S", tip->GetBlockTime()));
+    } else {
+        LogPrintf("%s:  Genesis rejected. This will not end well.\n", __func__);
+    }
     CheckForkWarningConditions();
 }
 


### PR DESCRIPTION
Hey there,

This is the user configurable blocksize setting from bitcoin classic, the clientversion
stuff comes from the bip100 pull request, because somehow classic changed
a lot there and has a new file Application.cpp I could not figure out how to do this myself :).

In the bip100 PR it defaulted to 64bit int, but the classic stuff has 32bit int, so I changed it also to 32bit. This should still allow for plenty enough blockspace for now.

So far it seems to work fine, compiles and runs, it shows the EB value in useragent on a different node if I call `getpeerinfo`. I also mined a few blocks in `-regtest` mode and they seem to contain the EB value.
But I have not actually tried to create >1MB blocks yet, this surely needs some review and testing.

Also there is a small cosmetic error: I could not figure out where to place
`std::vector<unsigned char> m_coinbaseComment;` in `miner.h`, it either failed with not declared errors or it seemed to declare it multiple times somehow, not sure what I was doing wrong there. So I just placed it at the top of `miner.cpp`. At least this way it compiles fine.

greetings from the core-bitcoin :)